### PR TITLE
C11 fixes the valid reprs of _Bool

### DIFF
--- a/reference/src/representation/integers-floatingpoint.md
+++ b/reference/src/representation/integers-floatingpoint.md
@@ -49,9 +49,9 @@ The C integer types specify a minimum size, but not the exact size. For this rea
 ## Controversies
 There has been some debate about what to pick as the "official" behavior for bool:
 * Rust does what C does (this is what the lang team decided)
-    * and in all cases you care about, that is 1 byte that is 0 or 1
+    * and in all cases you care about, that is 1 byte
 or
-* Rust makes it 1 byte with values 0 or 1
+* Rust makes it 1 byte
     * and in all cases you care about, this is what C does
     
 Related discussions: [document the size of bool](https://github.com/rust-lang/rust/pull/46156), [bool== _Bool?](https://github.com/rust-rfcs/unsafe-code-guidelines/issues/53#issuecomment-447050232), [bool ABI](https://github.com/rust-lang/rust/pull/46176#issuecomment-359593446)


### PR DESCRIPTION
* [C11 6.2.5p2](http://port70.net/~nsz/c/c11/n1570.html#6.2.5p2): "An object declared as type `_Bool` is large enough to store the values `0` and `1`".

* [C11 6.2.6.2p5](http://port70.net/~nsz/c/c11/n1570.html#6.2.6.2p5): "For any integer type, the object representation where all the bits are zero shall be a representation of the value zero in that type.". This fixes the `false` bit-pattern to `0x0`.

* [C11 6.3.1.2p1](http://port70.net/~nsz/c/c11/n1570.html#6.3.1.2p1): "When any scalar value is converted to `_Bool`, the result is `0` if the value compares equal to `0`; otherwise, the result is `1`". Converting any C integer to `_Bool` creates an integer that contains either `0` or `1` - this fixes the `false` bit-pattern to `0x0` and the `true` bit-pattern to `0x1`.

* [C11 7.18p3](http://port70.net/~nsz/c/c11/n1570.html#7.18p3): "`true` which expands to the integer constant `1`, `false` which expands to the integer constant `0`" - this is not so relevant since these expand to "integer constant"s (and not `_Bool`s), so an integer to `_Bool` conversion needs to kick in to initialize a `_Bool`.

* [C11 Footnote 122](http://port70.net/~nsz/c/c11/n1570.html#note122): "While the number of bits in a `_Bool` object is at least `CHAR_BIT`, the width (number of sign and value bits) of a `_Bool` may be just `1` bit".

---

All in all, a `_Bool` can can contain two valid values, 0 and 1, all other representations appear to be trap representations but I cannot find any clear statement in the standard stating precisely this.

--

cc @mjbshaw