### PR TITLE
Add travis for building the book.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+dist: trusty
+language: rust
+
+before_install:
+  - cargo install mdbook --vers '0.2.2' --debug --force
+
+script:
+  - cd reference
+  - mdbook build
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  local-dir: reference/book
+  keep-history: false
+  on:
+    branch: master


### PR DESCRIPTION
For my own reading i've forked this repo and deployed to my own [github pages](https://crlf0710.github.io/unsafe-code-guidelines/). The config file is taken from the rustwasm/book repo.

`GITHUB_TOKEN` environment variable needs to be set on dashboard of travis-ci.com site. It can be generated by github profile -> developer settings -> personal access tokens page.